### PR TITLE
商品詳細表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,4 +1,5 @@
 class ItemsController < ApplicationController
+  before_action :set_item, only: :show
   before_action :move_to_new_user_session, except: [:index, :show]
 
   def index
@@ -6,7 +7,6 @@ class ItemsController < ApplicationController
   end
 
   def show
-    @item = Item.find(params[:id])
   end
 
   def new
@@ -26,6 +26,10 @@ class ItemsController < ApplicationController
 
   def item_params
     params.require(:item).permit(:image, :name, :description, :category_id, :status_id, :shipping_fee_id, :prefecture_id, :day_until_shipping_id, :price).merge(user_id: current_user.id)
+  end
+
+  def set_item
+    @item = Item.find(params[:id])
   end
 
   def move_to_new_user_session

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -5,6 +5,10 @@ class ItemsController < ApplicationController
     @items = Item.includes(:user)
   end
 
+  def show
+    @item = Item.find(params[:id])
+  end
+
   def new
     @item = Item.new
   end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -126,7 +126,6 @@
     <%= link_to '新規投稿商品', "#", class: "subtitle" %>
     <ul class='item-lists'>
       <% @items.each do |item|%>
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
         <li class='list'>
           <%= link_to item_path(item.id) do %>
           <div class='item-img-content'>
@@ -154,7 +153,6 @@
           <% end %>
         </li>
       <% end %>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
 
       <%# 商品がない場合のダミー %>
       <%# 商品がある場合は表示されないようにしましょう %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -128,7 +128,7 @@
       <% @items.each do |item|%>
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
         <li class='list'>
-          <%= link_to "#" do %>
+          <%= link_to item_path(item.id) do %>
           <div class='item-img-content'>
             <%= image_tag item.image, class: "item-img" %>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -1,0 +1,107 @@
+<%= render "shared/header" %>
+
+<%# 商品の概要 %>
+<div class="item-show">
+  <div class="item-box">
+    <h2 class="name">
+      <%= "商品名" %>
+    </h2>
+    <div class='item-img-content'>
+      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%# 商品が売れている場合は、sould outの表示をしましょう。 %>
+      <div class='sold-out'>
+        <span>Sold Out!!</span>
+      </div>
+      <%# //商品が売れている場合は、sould outの表示をしましょう。 %>
+    </div>
+    <div class="item-price-box">
+      <span class="item-price">
+        ¥ 999,999,999
+      </span>
+      <span class="item-postage">
+        (税込) 送料込み
+      </span>
+    </div>
+
+    <%# ログインしていて、なおかつ、ログインしているユーザと出品しているユーザが同一人物でないとき表示しましょう。 %>
+
+    <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
+    <p class='or-text'>or</p>
+    <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
+
+    <%# 商品が売れていない場合はこちらを表示しましょう %>
+    <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
+    <%# //商品が売れていない場合はこちらを表示しましょう %>
+
+    <%# //ログインしていて、なおかつ、ログインしているユーザと出品しているユーザが同一人物でないとき表示しましょう。 %>
+
+    <div class="item-explain-box">
+      <span><%= "商品説明" %></span>
+    </div>
+    <table class="detail-table">
+      <tbody>
+        <tr>
+          <th class="detail-item">出品者</th>
+          <td class="detail-value"><%= "出品者名" %></td>
+        </tr>
+        <tr>
+          <th class="detail-item">カテゴリー</th>
+          <td class="detail-value"><%= "カテゴリー名" %></td>
+        </tr>
+        <tr>
+          <th class="detail-item">商品の状態</th>
+          <td class="detail-value"><%= "商品の状態" %></td>
+        </tr>
+        <tr>
+          <th class="detail-item">配送料の負担</th>
+          <td class="detail-value"><%= "発送料の負担" %></td>
+        </tr>
+        <tr>
+          <th class="detail-item">発送元の地域</th>
+          <td class="detail-value"><%= "発送元の地域" %></td>
+        </tr>
+        <tr>
+          <th class="detail-item">発送日の目安</th>
+          <td class="detail-value"><%= "発送日の目安" %></td>
+        </tr>
+      </tbody>
+    </table>
+    <div class="option">
+      <div class="favorite-btn">
+        <%= image_tag "star.png" ,class:"favorite-star-icon" ,width:"20",height:"20"%>
+        <span>お気に入り 0</span>
+      </div>
+      <div class="report-btn">
+        <%= image_tag "flag.png" ,class:"report-flag-icon" ,width:"20",height:"20"%>
+        <span>不適切な商品の通報</span>
+      </div>
+    </div>
+  </div>
+  <%# /商品の概要 %>
+
+  <div class="comment-box">
+    <form>
+      <textarea class="comment-text"></textarea>
+      <p class="comment-warn">
+        相手のことを考え丁寧なコメントを心がけましょう。
+        <br>
+        不快な言葉遣いなどは利用制限や退会処分となることがあります。
+      </p>
+      <button type="submit" class="comment-btn">
+        <%= image_tag "comment.png" ,class:"comment-flag-icon" ,width:"20",height:"25"%>
+        <span>コメントする<span>
+      </button>
+    </form>
+  </div>
+  <div class="links">
+    <a href="#" class="change-item-btn">
+      ＜ 前の商品
+    </a>
+    <a href="#" class="change-item-btn">
+      後ろの商品 ＞
+    </a>
+  </div>
+  <a href="#" class='another-item'><%= "商品のカテゴリー名" %>をもっと見る</a>
+</div>
+
+<%= render "shared/footer" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,7 +4,7 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.name %>
     </h2>
     <div class='item-img-content'>
       <%= image_tag @item.image ,class:"item-box-img" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -40,7 +40,7 @@
    
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.description %></span>
     </div>
     <table class="detail-table">
       <tbody>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -23,18 +23,21 @@
       </span>
     </div>
 
-    <%# ログインしていて、なおかつ、ログインしているユーザと出品しているユーザが同一人物でないとき表示しましょう。 %>
+    <%# ログインしていて、なおかつ、ログインしているユーザと出品しているユーザが同一人物である場合のみ、商品の編集と削除を行える %>
     <% if user_signed_in? && current_user.id == @item.user.id %>
       <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
       <p class='or-text'>or</p>
       <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
     <% end %>
 
+    <%# ログインしていて、なおかつ、ログインしているユーザと出品しているユーザが同一人物でない場合のみ、商品購入のリンクを踏める %>
     <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
+    <% if user_signed_in? && current_user.id != @item.user.id %>
+      <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
+    <% end %>
     <%# //商品が売れていない場合はこちらを表示しましょう %>
 
-    <%# //ログインしていて、なおかつ、ログインしているユーザと出品しているユーザが同一人物でないとき表示しましょう。 %>
+   
 
     <div class="item-explain-box">
       <span><%= "商品説明" %></span>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -24,10 +24,11 @@
     </div>
 
     <%# ログインしていて、なおかつ、ログインしているユーザと出品しているユーザが同一人物でないとき表示しましょう。 %>
-
-    <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
-    <p class='or-text'>or</p>
-    <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
+    <% if user_signed_in? && current_user.id == @item.user.id %>
+      <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
+      <p class='or-text'>or</p>
+      <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
+    <% end %>
 
     <%# 商品が売れていない場合はこちらを表示しましょう %>
     <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -46,27 +46,27 @@
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.status.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.shipping_fee.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.prefecture.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.day_until_shipping.name %></td>
         </tr>
       </tbody>
     </table>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -23,21 +23,17 @@
       </span>
     </div>
 
-    <%# ログインしていて、なおかつ、ログインしているユーザと出品しているユーザが同一人物である場合のみ、商品の編集と削除を行える %>
     <% if user_signed_in? && current_user.id == @item.user.id %>
       <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
       <p class='or-text'>or</p>
       <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
     <% end %>
 
-    <%# ログインしていて、なおかつ、ログインしているユーザと出品しているユーザが同一人物でない場合のみ、商品購入のリンクを踏める %>
     <%# 商品が売れていない場合はこちらを表示しましょう %>
     <% if user_signed_in? && current_user.id != @item.user.id %>
       <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
     <% end %>
     <%# //商品が売れていない場合はこちらを表示しましょう %>
-
-   
 
     <div class="item-explain-box">
       <span><%= @item.description %></span>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -7,7 +7,7 @@
       <%= "商品名" %>
     </h2>
     <div class='item-img-content'>
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag @item.image ,class:"item-box-img" %>
       <%# 商品が売れている場合は、sould outの表示をしましょう。 %>
       <div class='sold-out'>
         <span>Sold Out!!</span>
@@ -16,7 +16,7 @@
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        ¥ <%= @item.price %>
       </span>
       <span class="item-postage">
         (税込) 送料込み

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   root "items#index"
   devise_for :users
-  resources :items, only: [:index, :new, :create]
+  resources :items, only: [:index,:show, :new, :create]
 end


### PR DESCRIPTION
# What
- ログアウト状態でも商品詳細ページを閲覧できる機能を実装
- 出品者にしか商品の編集・削除のリンクが踏めないようにする機能を実装
- 出品者以外（且つログインしたユーザー）のみ商品購入のリンクが踏める機能を実装
- 商品出品時に登録した情報が見られるようにする機能を実装
- 商品出品時に登録した画像を表示する機能を実装

# Why
商品詳細ページを作成するため

画面キャプチャ
[商品説明](https://gyazo.com/39259ec98ceb5eca950998da4c2d57e7)
[ログアウト状態でも商品詳細ページを閲覧できること](https://gyazo.com/3592bf1d9c5fb88a56523d8ce358aad0)
[出品者にしか商品の編集・削除のリンクが踏めないようになっていること](https://gyazo.com/08835ffe18dba6225c570f1dd861218e)
[出品者以外（且つログインしたユーザー）のみ商品購入のリンクが踏めること](https://gyazo.com/12b724aebe977f2a89cadeedf11d3334)