### PR TITLE
画面遷移時にイベントが発火しない不具合の修正

### DIFF
--- a/app/javascript/profit.js
+++ b/app/javascript/profit.js
@@ -1,9 +1,5 @@
 function calculate_profit() {
   const price = document.getElementById("item_price");
-  if (price.getAttribute("data-load") != null) {
-    return null;
-  }
-  price.setAttribute("data-load", "true");
   price.addEventListener("input", (e) => {
     let fee = document.getElementById("add-tax-price");
     let profit = document.getElementById("profit");
@@ -15,8 +11,7 @@ function calculate_profit() {
       profit.innerHTML = "半角数字のみ入力可能"
     }
 
-    e.preventDefault();
     });
 }
 
-setInterval(calculate_profit, 1000);
+window.addEventListener("load", calculate_profit);

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -181,8 +181,6 @@
 </div>
 <div class='purchase-btn'>
   <span class='purchase-btn-text'>出品する</span>
-  <a href="/items/new">
-    <%= image_tag 'camera.png' , size: '185x50' ,class: "purchase-btn-icon" %>
-  </a>
+  <%= link_to image_tag('camera.png' , size: '185x50',class: "purchase-btn-icon"), new_item_path, method: :get %>
 </div>
 <%= render "shared/footer" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -31,7 +31,7 @@
 
     <% if @item.order.nil? %>
       <% if user_signed_in? && current_user.id != @item.user.id %>
-        <%= link_to '購入画面に進む', item_orders_path(@item.id) ,class:"item-red-btn"%>
+        <%= link_to '購入画面に進む', item_orders_path(@item.id) ,class:"item-red-btn", method: :get %>
       <% end %>
     <% end %>
 


### PR DESCRIPTION
コードレビューを依頼するべき箇所では無かったら申し訳ありません！すでにLGTMをもらっている部分なのですが、個人的に気になったので修正しました。

# What
- 画面遷移時にwindow.addEventListener(“load”, 関数)がイベント発火するように、link_toにmethod: :getを追加
- window.addEventListener(“load”, 関数)が正常に動作するようになったので、profit.jsにおいてsetIntervalでイベント発火させていた所をwindow.addEventListener(“load”, 関数)に変更

# Why
link_toで画面遷移しただけではwindow.addEventListener(“load”, 関数)がイベント発火せず、一回画面の再読み込みを挟まないと想定通りの動作が得られなかったため。