### PR TITLE
画面遷移時にイベントが発火しない不具合を修正(editのみ修正忘れ)

### DIFF
--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -24,7 +24,7 @@
     </div>
 
     <% if user_signed_in? && current_user.id == @item.user.id %>
-      <%= link_to '商品の編集', edit_item_path(@item.id), class: "item-red-btn" %>
+      <%= link_to '商品の編集', edit_item_path(@item.id), class: "item-red-btn", method: :get %>
       <p class='or-text'>or</p>
       <%= link_to '削除', item_path(@item.id), method: :delete, class:'item-destroy' %>
     <% end %>


### PR DESCRIPTION
# What
編集ページにlink_toで遷移した時に正常にwindow.addEventListener("load", 関数)がイベント発火するように修正

# Why
ページ遷移しただけではイベント発火していなかったため