### PR TITLE
クレジットカード処理のエラーハンドリング 

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,7 +12,7 @@ class ApplicationController < ActionController::Base
 
   def basic_auth
     authenticate_or_request_with_http_basic do |username, password|
-     username == ENV["BASIC_AUTH_USER"] && password == ENV["BASIC_AUTH_PASSWORD"]
-   end
+      username == ENV['BASIC_AUTH_USER'] && password == ENV['BASIC_AUTH_PASSWORD']
+    end
   end
 end

--- a/app/javascript/card.js
+++ b/app/javascript/card.js
@@ -4,6 +4,15 @@ const pay = () => {
   form.addEventListener("submit", (e) => {
     e.preventDefault();
 
+    const sendWithoutCardInfo = () => {
+      document.getElementById("order_destination_number").removeAttribute("name");
+      document.getElementById("order_destination_cvc").removeAttribute("name");
+      document.getElementById("order_destination_exp_month").removeAttribute("name");
+      document.getElementById("order_destination_exp_year").removeAttribute("name");
+      document.getElementById("charge-form").submit();
+      document.getElementById("charge-form").reset();
+    }
+
     const formResult = document.getElementById("charge-form");
     const formData = new FormData(formResult);
 
@@ -20,15 +29,10 @@ const pay = () => {
         const renderDom = document.getElementById("charge-form");
         const tokenObj = `<input value=${token} type="hidden" name='token'>`;
         renderDom.insertAdjacentHTML("beforeend", tokenObj);
-
-        document.getElementById("order_destination_number").removeAttribute("name");
-        document.getElementById("order_destination_cvc").removeAttribute("name");
-        document.getElementById("order_destination_exp_month").removeAttribute("name");
-        document.getElementById("order_destination_exp_year").removeAttribute("name");
-
-        document.getElementById("charge-form").submit();
-        document.getElementById("charge-form").reset();
+        sendWithoutCardInfo()
       } else {
+        window.alert('購入処理に失敗しました。\nお手数ですが最初からやり直してください。')
+        sendWithoutCardInfo()
       }
     });
   });

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -8,9 +8,7 @@
     </h1>
   </div>
 
-  <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
-  <%# render 'shared/error_messages', model: f.object %>
-  <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
+  <%= render partial: 'shared/error_messages', locals: { model: f.object } %>
 
   <div class="form-group">
     <div class='form-text-wrap'>


### PR DESCRIPTION
# What
- クレジットカード購入処理失敗時の挙動を追加
- サインアップ失敗時にエラーメッセージ を出すのを忘れてたので微修正

# Why
クレジットカード処理のエラーハンドリング ができておらず、カード情報を間違うとそのまま処理が停止していたため